### PR TITLE
Updated routenames for controllers

### DIFF
--- a/backend/DMA-FinalProject/DMA-FinalProject.API/Controllers/CookieController.cs
+++ b/backend/DMA-FinalProject/DMA-FinalProject.API/Controllers/CookieController.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace DMA_FinalProject.API.Controllers
 {
-    [Route("api/[controller]")]
+    [Route("api/[controller]s")]
     [ApiController]
     public class CookieController : ControllerBase
     {

--- a/backend/DMA-FinalProject/DMA-FinalProject.API/Controllers/DomainController.cs
+++ b/backend/DMA-FinalProject/DMA-FinalProject.API/Controllers/DomainController.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace DMA_FinalProject.API.Controllers
 {
-    [Route("domains")]
+    [Route("api/[controller]s")]
     [ApiController]
     public class DomainController : ControllerBase
     {

--- a/backend/DMA-FinalProject/DMA-FinalProject.API/Controllers/EmployeeController.cs
+++ b/backend/DMA-FinalProject/DMA-FinalProject.API/Controllers/EmployeeController.cs
@@ -8,7 +8,7 @@ using DMA_FinalProject.API.Authentication;
 
 namespace DMA_FinalProject.API.Controllers
 {
-    [Route("employees")]
+    [Route("api/[controller]s")]
     [ApiController]
     public class EmployeeController : ControllerBase
     {

--- a/backend/DMA-FinalProject/DMA-FinalProject.API/Controllers/UserController.cs
+++ b/backend/DMA-FinalProject/DMA-FinalProject.API/Controllers/UserController.cs
@@ -8,7 +8,7 @@ using DMA_FinalProject.API.Authentication;
 
 namespace DMA_FinalProject.API.Controllers
 {
-    [Route("users")]
+    [Route("api/[controller]s")]
     [ApiController]
     public class UserController : Controller
     {


### PR DESCRIPTION
routes now correctly display as "api/[controller]s"